### PR TITLE
Add ability to show and handle checkboxes in task description

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ There are 2 ways to use the taskboard:
 ### Print status reports
 ![Status report](https://user-images.githubusercontent.com/9609820/55243657-f2b6e300-523f-11e9-969c-dbdebf350f57.png)
 
+### Checklists in the task excerpt
+You can add a checklist to your task, which will be shown in the excerpt in the taskboard like this:
+
+![Checklist](https://user-images.githubusercontent.com/1270412/126763301-8b464632-b8f5-458f-a8a6-9be753761070.PNG)
+
+To add a checkbox, add a `[]/[ ]` or `[x]/[X]` for an unchecked or a checked box, respectively, at the beginning of the line, e.g. for the example above:
+
+```
+[ ] Subtask 1
+[X] Subtask 2
+[ ] Subtask 3
+```
+
+When checking or unchecking a box, the task's description will be updated accordingly.
+
 ### Supported platforms 
 Tested with Outlook 2013 and 2016 running on Windows 7/8.1/10.
 

--- a/kanban.html
+++ b/kanban.html
@@ -81,8 +81,8 @@
                                 <span ng-show="task.reminderSet" ng-class="isOverdue(task.duedate,task.startdate)" class="pull-right">(Reminder: {{ task.reminderTime | date:(config.DATE_FORMAT + " " + config.TIME_FORMAT) }}) </span>
                             </header>
                             <div class="panel-body">
-                                <span ng-if=" ( config.EXCERPT_LINEBREAKS ) " ng-bind-html="trust(task.notes)"></span>
-                                <span ng-if=" ( !config.EXCERPT_LINEBREAKS ) " ng-bind="task.notes"></span>
+                                <span ng-if=" ( config.EXCERPT_PARSE ) " ng-bind-html="trust(task.notes)"></span>
+                                <span ng-if=" ( !config.EXCERPT_PARSE ) " ng-bind="task.notes"></span>
                             </div>
                             <footer class="text-right" ng-style="getFooterStyle(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left"><span class="glyphicon glyphicon-tag"></span>
@@ -128,8 +128,8 @@
                                 <span ng-show="task.reminderSet" ng-class="isOverdue(task.duedate,task.startdate)" class="pull-right">(Reminder: {{ task.reminderTime | date:(config.DATE_FORMAT + " " + config.TIME_FORMAT) }}) </span>
                             </header>
                             <div class="panel-body">
-                                <span ng-if=" ( config.EXCERPT_LINEBREAKS ) " ng-bind-html="trust(task.notes)"></span>
-                                <span ng-if=" ( !config.EXCERPT_LINEBREAKS ) " ng-bind="task.notes"></span>
+                                <span ng-if=" ( config.EXCERPT_PARSE ) " ng-bind-html="trust(task.notes)"></span>
+                                <span ng-if=" ( !config.EXCERPT_PARSE ) " ng-bind="task.notes"></span>
                             </div>
                             <footer class="text-right" ng-style="getFooterStyle(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left"><span class="glyphicon glyphicon-tag"></span>
@@ -175,8 +175,8 @@
                                 <!-- <span ng-show="( config.INPROGRESS_FOLDER.DISPLAY_PROPERTIES.OWNER )" class="pull-right"><span class="glyphicon glyphicon-user"></span> {{ task.owner }} </span> -->
                             </header>
                             <div class="panel-body">
-                                <span ng-if=" ( config.EXCERPT_LINEBREAKS ) " ng-bind-html="trust(task.notes)"></span>
-                                <span ng-if=" ( !config.EXCERPT_LINEBREAKS ) " ng-bind="task.notes"></span>
+                                <span ng-if=" ( config.EXCERPT_PARSE ) " ng-bind-html="trust(task.notes)"></span>
+                                <span ng-if=" ( !config.EXCERPT_PARSE ) " ng-bind="task.notes"></span>
                             </div>
                             <footer class="text-right" ng-style="getFooterStyle(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left"><span class="glyphicon glyphicon-tag"></span>
@@ -224,8 +224,8 @@
                                 <span ng-show="task.reminderSet" ng-class="isOverdue(task.duedate,task.startdate)" class="pull-right">(Reminder: {{ task.reminderTime | date:(config.DATE_FORMAT + " " + config.TIME_FORMAT) }}) </span>
                             </header>
                             <div class="panel-body">
-                                <span ng-if=" ( config.EXCERPT_LINEBREAKS ) " ng-bind-html="trust(task.notes)"></span>
-                                <span ng-if=" ( !config.EXCERPT_LINEBREAKS ) " ng-bind="task.notes"></span>
+                                <span ng-if=" ( config.EXCERPT_PARSE ) " ng-bind-html="trust(task.notes)"></span>
+                                <span ng-if=" ( !config.EXCERPT_PARSE ) " ng-bind="task.notes"></span>
                             </div>
                             <footer class="text-right" ng-style="getFooterStyle(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left"><span class="glyphicon glyphicon-tag"></span>
@@ -266,8 +266,8 @@
                                 <span class="pull-right">(Completed: {{ task.completeddate | date:config.DATE_FORMAT }}) </span>
                             </header>
                             <div class="panel-body">
-                                <span ng-if=" ( config.EXCERPT_LINEBREAKS ) " ng-bind-html="trust(task.notes)"></span>
-                                <span ng-if=" ( !config.EXCERPT_LINEBREAKS ) " ng-bind="task.notes"></span>
+                                <span ng-if=" ( config.EXCERPT_PARSE ) " ng-bind-html="trust(task.notes)"></span>
+                                <span ng-if=" ( !config.EXCERPT_PARSE ) " ng-bind="task.notes"></span>
                             </div>
                             <footer class="text-right" ng-style="getFooterStyle(task.categories)">
                                 <div ng-if="(task.categories != '')" class="pull-left"><span class="glyphicon glyphicon-tag"></span>


### PR DESCRIPTION
I was missing a feature to be able to integrate "subtasks" in the form of Checkboxes within the task description.

You can now add a list to the task description, where each line starts with a '-', similar to markdown:

<img width="346" alt="Taskboard_Description_orig" src="https://user-images.githubusercontent.com/1270412/126524465-b9988369-ec0a-458c-bf52-6fd0cf4dbcb1.PNG">

This will be shown with checkboxes in the Task overview:

<img width="160" alt="Taskboard_Checkboxes" src="https://user-images.githubusercontent.com/1270412/126524560-6c946d8a-bf54-404f-95e4-2b7cce133e70.PNG">

When you check one of the checkboxes, the '-' is replaced with a '+' in the task to save the change.

<img width="346" alt="Taskboard_Description" src="https://user-images.githubusercontent.com/1270412/126524346-16ba84f4-130e-4514-89f1-c23e28bdb702.PNG">

What do you think about that? The Readme would have to be updated before a merge.