### PR TITLE
Add support to order tasks by drag drops and dragging mail items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are 2 ways to use the taskboard:
 
   1. As an Outlook folder Home Page
   2. Directly from Internet Explorer
-  
+
 ![Outlook Taskboard](http://evrenvarol.github.io/outlook-taskboard/img/outlook-taskboard.png)
 
 # Features
@@ -46,7 +46,7 @@ To add a checkbox, add a `[]/[ ]` or `[x]/[X]` for an unchecked or a checked box
 
 When checking or unchecking a box, the task's description will be updated accordingly.
 
-### Supported platforms 
+### Supported platforms
 Tested with Outlook 2013 and 2016 running on Windows 7/8.1/10.
 
 The taskboard can also be opened in Internet Explorer. Due to limitations with ActiveX controls, only Internet Explorer 9/10 and 11 are supported.
@@ -103,7 +103,7 @@ The further setup depends on how you want to use the taskboard. While the soluti
   ![IE Local Intranet Zone Setting](http://evrenvarol.github.io/outlook-taskboard/img/ie-localintranet-activexscript-enable.png)
 
   * Open the page **kanban.html** in Internet Explorer.
-  
+
     *Pro tip: Set kanban.html as your Internet Explorer homepage. (What else are you going to use IE for anyway...)*
 
     Note that any other browsers than Internet Explorer are __not supported__ (not even Edge), as IE's ActiveX features are required for access to Outlook data.
@@ -117,7 +117,7 @@ This is an example for the configuration of the "Next" lane:
 ```javascript
 ...
   "NEXT_FOLDER": {
-    "ACTIVE": true, 
+    "ACTIVE": true,
     "NAME": "",
     "TITLE": "NEXT",
     "LIMIT": 20,
@@ -125,7 +125,7 @@ This is an example for the configuration of the "Next" lane:
     "RESTRICT": "",
     "DISPLAY_PROPERTIES": {
       "OWNER": false,
-      "PERCENT": true, 
+      "PERCENT": true,
       "TOTALWORK": true
     },
 ...
@@ -154,6 +154,8 @@ This is an example for the configuration of the "Next" lane:
 * The `Sort` value can be updated to change the sorting criteria and their order.
 
 * It is also possible to add multiple order criteria such as: `"SORT": "-priority,duedate,startdate,categoryNames",`
+
+* Another possibility is to sort tasks manually by drag and drop. To enable this, set `"USE_ORDINALS": true,`. This will override the sorting criteria for the individual columns.
 
 ### Task Template
 

--- a/js/app.js
+++ b/js/app.js
@@ -63,6 +63,14 @@ function checkItem(checkBox, taskID, checkIdx) {
     taskItem.save();
 }
 
+// https://docs.microsoft.com/en-us/office/vba/api/outlook.olobjectclass
+const OL_MAIL_ITEM = 43;
+const OL_TASK_ITEM = 48;
+
+ // https://docs.microsoft.com/en-us/office/vba/api/outlook.olmarkinterval
+const OL_MARK_COMPLETE = 5;
+const OL_MARK_TODAY = 0;
+
 tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
 
     // DeepDiff.observableDiff(def, curr, function(d) {
@@ -156,14 +164,29 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                         var taskitem = outlookNS.GetItemFromID(ui.item.sortable.model.entryID);
                         var itemChanged = false;
 
-                        // set new status, if different and if it's a task item (not mail)
-                        if (taskitem.Status != newstatus && taskitem.Class == 48) {
+                        // set new status, if different
+                        if (
+                            (taskitem.Class == OL_TASK_ITEM && taskitem.Status != newstatus) ||
+                            taskitem.Class == OL_MAIL_ITEM && taskitem.FlagRequest != taskStatus(newstatus)
+                        ) {
                             $scope.dragged = true;
-                            taskitem.Status = newstatus;
+                            if (taskitem.Class == OL_TASK_ITEM) {
+                                taskitem.Status = newstatus;
+                            }
+                            else {
+                                if (newstatus == $scope.config.STATUS.COMPLETE.VALUE) {
+                                    taskitem.MarkAsTask(OL_MARK_COMPLETE);
+                                }
+                                // Changed from complete to uncomplete
+                                else if ( taskitem.FlagRequest == taskStatus($scope.config.STATUS.COMPLETE.VALUE) ) {
+                                    taskitem.MarkAsTask(OL_MARK_TODAY);
+                                }
+                                taskitem.FlagRequest = taskStatus(newstatus);
+                            }
                             taskitem.Save();
                             itemChanged = true;
                             ui.item.sortable.model.status = taskStatus(newstatus);
-                            ui.item.sortable.model.completeddate = new Date(taskitem.DateCompleted)
+                            ui.item.sortable.model.completeddate = new Date(taskitem.DateCompleted);
                             $scope.dragged = false;
                         }
 
@@ -282,7 +305,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
 
             switch (task.Class) {
                 // Task object
-                case 48:
+                case OL_TASK_ITEM:
                     if (task.Status == folderStatus) {
                         taskArray.push({
                             entryID: task.EntryID,
@@ -311,9 +334,11 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                     break;
 
                 // Mail object (flagged mail)
-                case 43:
-                    var flaggedMailStatus = $scope.config.INCLUDE_TODOS_STATUS;
-                    if (folderStatus == flaggedMailStatus) {
+                case OL_MAIL_ITEM:
+                    if (task.FlagRequest == "Follow up") { // Initial FlagRequest value set by Outlook
+                        task.FlagRequest = taskStatus($scope.config.INITIAL_MAIL_STATUS);
+                    }
+                    if (task.FlagRequest == taskStatus(folderStatus)) {
                         taskArray.push({
                             entryID: task.EntryID,
                             subject: task.TaskSubject,
@@ -327,7 +352,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             categoryNames: task.Categories,
                             notes: taskExcerpt(task.Body, $scope.config.TASKNOTE_EXCERPT, task.EntryID),
                             body: task.Body,
-                            status: taskStatus(flaggedMailStatus),
+                            status: taskStatus(task.FlagRequest),
                             oneNoteTaskID: getUserProp(task, "OneNoteTaskID"),
                             oneNoteURL: getUserProp(task, "OneNoteURL"),
                             percent: 0,
@@ -782,7 +807,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
         mailBody += "<tr><td>PRIVACY_FILTER</td><td>if true, then you can use separate boards for private and publis tasks</td></tr>";
         mailBody += "<tr><td>USE_ORDINALS</td><td>if true, then you can drag and drop issues i a column to sort them. This will override the sorting settings for all columns.<td></tr>";
         mailBody += "<tr><td>INCLUDE_TODOS</td><td>Search the To Do folder instead of the Tasks folder. This includes flagged mails. Note that flagged mails cannot be moved across lanes as they do not have statuses.</td></tr>";
-        mailBody += "<tr><td>INCLUDE_TODOS_STATUS</td><td>Choose which status ID should be assigned to tasks generated from flagged mails. These cannot be moved across lanes.</td></tr>";
+        mailBody += "<tr><td>INITIAL_MAIL_STATUS</td><td>Choose which status ID should initially be assigned to tasks generated from flagged mails.</td></tr>";
         mailBody += "<tr><td>EXCERPT_PARSE</td><td>If true, line breaks and checkboxes from the task body are parsed and displayed in the task excerpt. Other HTML content in the excerpt is displayed as well. This introduces a <b>potential vulnerability</b> to XSS attacks! However, this is probably not that relevant with personal Outlook tasks.</td></tr>";
         mailBody += "<tr><td>STATUS</td><td>The values and descriptions for the task statuses. The text can be changed for the status report</td></tr>";
         mailBody += "<tr><td>COMPLETED</td><td>Define what to do with completed tasks after x days: NONE, HIDE, ARCHIVE or DELETE</td></tr>";
@@ -1296,7 +1321,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
             "PRIVACY_FILTER": true,
             "USE_ORDINALS": false,
             "INCLUDE_TODOS": false,
-            "INCLUDE_TODOS_STATUS": 0,
+            "INITIAL_MAIL_STATUS": 0,
             "EXCERPT_PARSE": true,
             "STATUS": {
                 "NOT_STARTED": {

--- a/js/app.js
+++ b/js/app.js
@@ -204,7 +204,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
         tasks.forEach(function(item, i, _) {
             if (item.ordinal != i) {
                 var taskitem = outlookNS.GetItemFromID(item.entryID);
-                taskitem.Ordinal = i;
+                taskitem.ToDoTaskOrdinal = i;
                 taskitem.Save();
             }
         });
@@ -288,7 +288,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             entryID: task.EntryID,
                             subject: task.Subject,
                             priority: task.Importance,
-                            ordinal: task.Ordinal,
+                            ordinal: task.ToDoTaskOrdinal,
                             startdate: new Date(task.StartDate),
                             duedate: new Date(task.DueDate),
                             completeddate: new Date(task.DateCompleted),
@@ -318,7 +318,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             entryID: task.EntryID,
                             subject: task.TaskSubject,
                             priority: task.Importance,
-                            ordinal: task.Ordinal,
+                            ordinal: task.ToDoTaskOrdinal,
                             startdate: new Date(task.TaskStartDate),
                             duedate: new Date(task.TaskDueDate),
                             completeddate: new Date(task.TaskCompletedDate),

--- a/js/app.js
+++ b/js/app.js
@@ -1030,6 +1030,13 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 var newstatus = $scope.config.STATUS.WAITING.VALUE;
                 break;
         };
+
+        if ($scope.config.INCLUDE_TODOS) {
+            // Cannot create items in To-Do List directly. Create them in Tasks instead.
+            // They will appear in To-Do List as well.
+            tasksfolder = outlookNS.GetDefaultFolder(13);
+        }
+
         // create a new task item object in outlook
         var taskitem = tasksfolder.Items.Add();
 

--- a/js/app.js
+++ b/js/app.js
@@ -1029,6 +1029,13 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 var newstatus = $scope.config.STATUS.WAITING.VALUE;
                 break;
         };
+
+        if ($scope.config.INCLUDE_TODOS) {
+            // Cannot create items in To-Do List directly. Create them in Tasks instead.
+            // They will appear in To-Do List as well.
+            tasksfolder = outlookNS.GetDefaultFolder(13);
+        }
+
         // create a new task item object in outlook
         var taskitem = tasksfolder.Items.Add();
 

--- a/js/app.js
+++ b/js/app.js
@@ -157,8 +157,8 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                         var taskitem = outlookNS.GetItemFromID(ui.item.sortable.model.entryID);
                         var itemChanged = false;
 
-                        // set new status, if different
-                        if (taskitem.Status != newstatus) {
+                        // set new status, if different and if it's a task item (not mail)
+                        if (taskitem.Status != newstatus && taskitem.Class == 48) {
                             $scope.dragged = true;
                             taskitem.Status = newstatus;
                             taskitem.Save();

--- a/js/app.js
+++ b/js/app.js
@@ -205,7 +205,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
         tasks.forEach(function(item, i, _) {
             if (item.ordinal != i) {
                 var taskitem = outlookNS.GetItemFromID(item.entryID);
-                taskitem.Ordinal = i;
+                taskitem.ToDoTaskOrdinal = i;
                 taskitem.Save();
             }
         });
@@ -289,7 +289,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             entryID: task.EntryID,
                             subject: task.Subject,
                             priority: task.Importance,
-                            ordinal: task.Ordinal,
+                            ordinal: task.ToDoTaskOrdinal,
                             startdate: new Date(task.StartDate),
                             duedate: new Date(task.DueDate),
                             completeddate: new Date(task.DateCompleted),
@@ -319,7 +319,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             entryID: task.EntryID,
                             subject: task.TaskSubject,
                             priority: task.Importance,
-                            ordinal: task.Ordinal,
+                            ordinal: task.ToDoTaskOrdinal,
                             startdate: new Date(task.TaskStartDate),
                             duedate: new Date(task.TaskDueDate),
                             completeddate: new Date(task.TaskCompletedDate),

--- a/js/app.js
+++ b/js/app.js
@@ -156,8 +156,8 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                         var taskitem = outlookNS.GetItemFromID(ui.item.sortable.model.entryID);
                         var itemChanged = false;
 
-                        // set new status, if different
-                        if (taskitem.Status != newstatus) {
+                        // set new status, if different and if it's a task item (not mail)
+                        if (taskitem.Status != newstatus && taskitem.Class == 48) {
                             $scope.dragged = true;
                             taskitem.Status = newstatus;
                             taskitem.Save();

--- a/js/app.js
+++ b/js/app.js
@@ -167,8 +167,12 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             $scope.dragged = false;
                         }
 
+                        if ($scope.config.INCLUDE_TODOS) {
+                            saveOrdinals(ui.item.sortable.sourceModel);
+                        }
+
                         // ensure the task is not moving into same folder
-                        if (taskitem.Parent.Name != tasksfolder.Name) {
+                        if (taskitem.Parent.Name != tasksfolder.Name && !$scope.config.INCLUDE_TODOS) {
                             // move the task item
                             taskitem = taskitem.Move(tasksfolder);
                             itemChanged = true;
@@ -179,7 +183,8 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                         }
 
                         if (itemChanged) {
-                            $scope.initTasks();
+                            // TODO Figure out if this is necessary? Seems to work fine (and much faster) without...
+                            // $scope.initTasks();
                         }
                     }
                 }
@@ -193,6 +198,15 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
             $scope.saveState();
         });
     };
+
+    // Aligns the Ordinal property of all tasks in a list according to the order of that list
+    // https://docs.microsoft.com/en-us/office/vba/api/outlook.taskitem.ordinal
+    var saveOrdinals = function (tasks) {
+        tasks.forEach(function(item, i, _) {
+            var taskitem = outlookNS.GetItemFromID(item.entryID);
+            taskitem.Ordinal = i;
+        });
+    }
 
     var getOutlookFolder = function (folderpath) {
         if (!$scope.config.INCLUDE_TODOS) {
@@ -210,7 +224,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 }
             }
         } else {
-            // Tasks folder
+            // To-do list folder
             var folder = outlookNS.GetDefaultFolder(28);
         }
         return folder;
@@ -272,6 +286,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             entryID: task.EntryID,
                             subject: task.Subject,
                             priority: task.Importance,
+                            ordinal: task.Ordinal,
                             startdate: new Date(task.StartDate),
                             duedate: new Date(task.DueDate),
                             completeddate: new Date(task.DateCompleted),
@@ -301,6 +316,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             entryID: task.EntryID,
                             subject: task.TaskSubject,
                             priority: task.Importance,
+                            ordinal: task.Ordinal,
                             startdate: new Date(task.TaskStartDate),
                             duedate: new Date(task.TaskDueDate),
                             completeddate: new Date(task.TaskCompletedDate),
@@ -332,6 +348,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
         // sort tasks
         var sortKeys;
         if (sort === undefined) { sortKeys = ["-priority"]; }
+        else if ($scope.config.INCLUDE_TODOS) { sortKeys = ["ordinal"] }
         else { sortKeys = sort.split(","); }
 
         var sortedTasks = taskArray.sort(fieldSorter(sortKeys));

--- a/js/app.js
+++ b/js/app.js
@@ -167,7 +167,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                             $scope.dragged = false;
                         }
 
-                        if ($scope.config.INCLUDE_TODOS) {
+                        if ($scope.config.USE_ORDINALS) {
                             saveOrdinals(ui.item.sortable.sourceModel);
                         }
 
@@ -183,8 +183,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                         }
 
                         if (itemChanged) {
-                            // TODO Figure out if this is necessary? Seems to work fine (and much faster) without...
-                            // $scope.initTasks();
+                            $scope.initTasks();
                         }
                     }
                 }
@@ -203,8 +202,11 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
     // https://docs.microsoft.com/en-us/office/vba/api/outlook.taskitem.ordinal
     var saveOrdinals = function (tasks) {
         tasks.forEach(function(item, i, _) {
-            var taskitem = outlookNS.GetItemFromID(item.entryID);
-            taskitem.Ordinal = i;
+            if (item.ordinal != i) {
+                var taskitem = outlookNS.GetItemFromID(item.entryID);
+                taskitem.Ordinal = i;
+                taskitem.Save();
+            }
         });
     }
 
@@ -310,7 +312,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
 
                 // Mail object (flagged mail)
                 case 43:
-                    var flaggedMailStatus = $scope.config.INCLUDE_TODOS_STATUS; // TO DO: make this configurable
+                    var flaggedMailStatus = $scope.config.INCLUDE_TODOS_STATUS;
                     if (folderStatus == flaggedMailStatus) {
                         taskArray.push({
                             entryID: task.EntryID,
@@ -347,8 +349,8 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
 
         // sort tasks
         var sortKeys;
-        if (sort === undefined) { sortKeys = ["-priority"]; }
-        else if ($scope.config.INCLUDE_TODOS) { sortKeys = ["ordinal"] }
+        if ($scope.config.USE_ORDINALS) { sortKeys = ["ordinal"] }
+        else if (sort === undefined) { sortKeys = ["-priority"]; }
         else { sortKeys = sort.split(","); }
 
         var sortedTasks = taskArray.sort(fieldSorter(sortKeys));
@@ -778,6 +780,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
         mailBody += "<tr><td>SAVE_STATE</td><td>if true, then the filters will be saved and re-used when the app is restarted</td></tr>";
         mailBody += "<tr><td>FILTER_REPORTS</td><td>if true, then the filters will be applied on status reports, too</td></tr>";
         mailBody += "<tr><td>PRIVACY_FILTER</td><td>if true, then you can use separate boards for private and publis tasks</td></tr>";
+        mailBody += "<tr><td>USE_ORDINALS</td><td>if true, then you can drag and drop issues i a column to sort them. This will override the sorting settings for all columns.<td></tr>";
         mailBody += "<tr><td>INCLUDE_TODOS</td><td>Search the To Do folder instead of the Tasks folder. This includes flagged mails. Note that flagged mails cannot be moved across lanes as they do not have statuses.</td></tr>";
         mailBody += "<tr><td>INCLUDE_TODOS_STATUS</td><td>Choose which status ID should be assigned to tasks generated from flagged mails. These cannot be moved across lanes.</td></tr>";
         mailBody += "<tr><td>EXCERPT_PARSE</td><td>If true, line breaks and checkboxes from the task body are parsed and displayed in the task excerpt. Other HTML content in the excerpt is displayed as well. This introduces a <b>potential vulnerability</b> to XSS attacks! However, this is probably not that relevant with personal Outlook tasks.</td></tr>";
@@ -1196,7 +1199,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 "NAME": "",
                 "TITLE": "BACKLOG",
                 "SORT": "-priority,duedate,categoryNames,subject",
-                "RESTRICT": "",
+                "RESTRICT": "[Complete] = false",
                 "DISPLAY_PROPERTIES": {
                     "OWNER": false,
                     "PERCENT": false,
@@ -1213,7 +1216,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 "TITLE": "NEXT",
                 "LIMIT": 20,
                 "SORT": "-priority,duedate,categoryNames,subject",
-                "RESTRICT": "",
+                "RESTRICT": "[Complete] = false",
                 "DISPLAY_PROPERTIES": {
                     "OWNER": false,
                     "PERCENT": false,
@@ -1229,7 +1232,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 "TITLE": "IN PROGRESS",
                 "LIMIT": 5,
                 "SORT": "-priority,duedate,categoryNames,subject",
-                "RESTRICT": "",
+                "RESTRICT": "[Complete] = false",
                 "DISPLAY_PROPERTIES": {
                     "OWNER": false,
                     "PERCENT": false,
@@ -1245,7 +1248,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
                 "TITLE": "WAITING",
                 "LIMIT": 0,
                 "SORT": "-priority,duedate,categoryNames,subject",
-                "RESTRICT": "",
+                "RESTRICT": "[Complete] = false",
                 "DISPLAY_PROPERTIES": {
                     "OWNER": false,
                     "PERCENT": false,
@@ -1284,6 +1287,7 @@ tbApp.controller('taskboardController', function ($scope, $filter, $sce) {
             "SAVE_STATE": true,
             "FILTER_REPORTS": true,
             "PRIVACY_FILTER": true,
+            "USE_ORDINALS": false,
             "INCLUDE_TODOS": false,
             "INCLUDE_TODOS_STATUS": 0,
             "EXCERPT_PARSE": true,


### PR DESCRIPTION
New features and bug fixes related to drag and drop, and to having INCLUDE_TODOS (mail items enabled).

With this change. task cards (both tasks and e-mail items) can be dragged within a column, and make the resulting order stick. This was done by setting the ToDoTaskOrdinal property of the TaskItem.

Added a new config parameter to enable or disable this feature, "USE_ORDINALS". If this is true, sorting on ordinals is forced and the other sorting config of individual columns will be ignored (it doesn't make sense to set ToDoTaskOrdinal and then sort on something else).

It is also possible to drag flagged mail items between the columns, as was suggested in #5. This is accomplished by setting the FlagRequest property. It is possible to drag it to and from the Completed column as well with expected results.

Renamed config parameter INCLUDE_TODOS_STATUS to INITIAL_MAIL_STATUS.

Fixed script errors with dragging a task item to another column, and dragging a mail item at all. Don't attempt to move tasks at all when INCLUDE_TODOS is set since all tasks come from the same "folder" in this case and it is not possible to have different subfolders when using this feature anyway. Don't attempt to set status for MailItems since that property does not exist for them.

Fixed so the buttons to add tasks work when INCLUDE_TODOS is set.

Changed default config slightly to avoid e-mails flagged as completed to appear in columns when INCLUDE_TODOS is enabled.

Some other small fixes.